### PR TITLE
Add Focus to content.json

### DIFF
--- a/src/lib/data/content.json
+++ b/src/lib/data/content.json
@@ -690,6 +690,12 @@
               "author": "Noel De Martin",
               "url": "https://umai.noeldemartin.com",
               "icon": "https://noeldemartin.com/logos/umai-small.svg"
+            },
+            {
+              "title": "Focus",
+              "author": "Noel De Martin",
+              "url": "https://focus.noeldemartin.com",
+              "icon": "https://noeldemartin.com/logos/focus-small.svg"
             }
           ]
         }


### PR DESCRIPTION
By the way, I noticed the live data doesn't actually match this file. For example, TiddlyWIki is listed as an app, but doesn't show up anywhere in this json file. Likewise, I added another app (Umai) 2 months ago and it's still missing from the website :/.