### PR TITLE
fix: inkandswitch favicon url and icon alt text

### DIFF
--- a/src/lib/data/content.json
+++ b/src/lib/data/content.json
@@ -10,7 +10,7 @@
               "title": "Local-first software: you own your data, in spite of the cloud",
               "author": "Ink & Switch",
               "url": "https://www.inkandswitch.com/local-first",
-              "icon": "https://www.inkandswitch.com/favicon.ico?v=1"
+              "icon": "https://www.inkandswitch.com/static/favicons/favicon.ico"
             },
             {
               "title": "Building data-centric apps with a reactive relational database",

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -153,7 +153,7 @@
 										href={item.url}
 										class="relative overflow-hidden rounded-lg border border-gray-200 bg-white p-3 transition-all hover:border-primary/20 hover:shadow-sm dark:border-gray-700 dark:bg-gray-800/50 dark:hover:border-primary/20"
 									>
-										<img src={item.icon} alt={item.title} class="mb-3 h-6 w-6" />
+										<img src={item.icon} alt="" class="mb-3 h-6 w-6" />
 
 										<h5 class="mb-1 text-lg font-semibold text-gray-900 dark:text-white">
 											{item.title}


### PR DESCRIPTION
Noticed a couple of small but connected UI bugs:

- inkandswitch's favicon link was broken
- falling back to the alt text resulted in the text overflowing, since the alt text was set to the full item.title val

<img width="468" height="402" alt="image" src="https://github.com/user-attachments/assets/608b7140-7e18-4624-bbde-84bde457f59b" />

So, this PR fixes the broken URL, but it also set the alt text to a blank string, since the item title is already displayed in the header directly below it. [This follows standards for such an img.](https://html.spec.whatwg.org/multipage/images.html#a-graphical-representation-of-some-of-the-surrounding-text) 

After these changes, the icon shows correctly:

<img width="464" height="304" alt="image" src="https://github.com/user-attachments/assets/1d39afb3-ff3e-4f86-b45a-8dabde552a40" />

Also, should another favicon link break in the future, it will be less detrimental to the UX (example below where I purposely broke the link):

<img width="461" height="298" alt="image" src="https://github.com/user-attachments/assets/cd77eff4-38c2-4069-aee1-6fd3b9231620" />


