### PR TITLE
Add p2panda to Sync Engines

### DIFF
--- a/src/lib/data/content.json
+++ b/src/lib/data/content.json
@@ -389,6 +389,12 @@
               "icon": "https://nextgraph.org/favicon.svg"
             },
             {
+              "title": "p2panda",
+              "author": "adzialocha",
+              "url": "https://p2panda.org/",
+              "icon": "https://p2panda.org/assets/images/p2panda.svg"
+            },
+            {
               "title": "PowerSync",
               "author": "JourneyApps",
               "url": "https://www.powersync.com",


### PR DESCRIPTION
p2panda is a local-first CRDT sync engine for GNOME apps

Website: https://p2panda.org
Author taken from: https://github.com/p2panda/p2panda/graphs/contributors