### PR TITLE
Add Present (bepresent.day) to directory apps

### DIFF
--- a/src/lib/data/directory/Item.json
+++ b/src/lib/data/directory/Item.json
@@ -993,6 +993,20 @@
 				"Categories": ["L", 40, 44],
 				"Uses": null
 			}
+		},
+		{
+			"id": 85,
+			"fields": {
+				"Main_Category": 1,
+				"Title": "Present",
+				"slug": "present",
+				"author": "rain",
+				"url": "https://bepresent.day",
+				"icon": "https://bepresent.day/icon-512.png",
+				"description": "A quiet daily mindfulness habit: sit with a breathing timer, or a short yoga flow or meditation, then leave one line about how the day went. Local-first by default \u2014 reflections live in localStorage, every sound and narration is a bundled file played locally, and no account is needed. Optional Google sign-in for cross-device backup.",
+				"Categories": null,
+				"Uses": null
+			}
 		}
 	]
 }


### PR DESCRIPTION
Adds [Present](https://bepresent.day) to the Apps section of the directory.

Present is a small daily mindfulness habit app: a breathing timer, short yoga flows and guided meditations, then one line about how the day went. It's local-first by default — reflections live in localStorage, all audio (ambient sounds, chimes, narration) is bundled and played locally with no third-party streaming, and no account is needed to start. Optional Google sign-in adds cross-device backup. Free, installable as a PWA.

Happy to adjust categories or wording if you'd like.