### PR TITLE
Add kgai to Apps to try

### DIFF
--- a/src/lib/data/content.json
+++ b/src/lib/data/content.json
@@ -723,6 +723,13 @@
                         "url": "https://bulkpictools.com",
                         "icon": "https://bulkpictools.com/favicon.svg",
                         "description": "Privacy-first, 100% browser-side image suite for bulk processing, powered by WebAssembly."
+                    },
+                    {
+                        "title": "kgai",
+                        "author": "kgai team",
+                        "url": "https://kgai.dev",
+                        "icon": "https://github.com/kgaidev.png",
+                        "description": "Local-first shared decision memory for AI dev teams. An append-only log of engineering decisions on your machine, synced through an S3 bucket you own."
                     }
                 ]
             }


### PR DESCRIPTION
Adds kgai to the Apps to try section. Disclosure up front, we build kgai.

kgai is a local-first shared decision memory for AI dev teams. Engineering decisions live in an append-only log on each dev's machine, the graph is derived locally, and team sync is opt-in through an S3 bucket you own. No server, no account, MIT licensed.

The entry follows the shape of the newest items in content.json (title, author, url, icon, description). Happy to adjust or drop the description field if you prefer the shorter form.