### PR TITLE
Add Loofah to the local-first apps directory

### DIFF
--- a/src/lib/data/directory/Item.json
+++ b/src/lib/data/directory/Item.json
@@ -993,6 +993,20 @@
 				"Categories": ["L", 40, 44],
 				"Uses": null
 			}
+		},
+		{
+			"id": 85,
+			"fields": {
+				"Main_Category": 1,
+				"Title": "Loofah",
+				"slug": "loofah",
+				"author": "Bart / Loofah contributors",
+				"url": "https://loofah.io",
+				"icon": "https://raw.githubusercontent.com/bart6114/loofah/main/apps/desktop/src-tauri/icons/stable/icon.png",
+				"description": "Loofah is a local-first Mac app for notes and meeting transcription. It transcribes audio on-device and keeps notes and transcripts as ordinary Markdown files in a filesystem vault.",
+				"Categories": ["L", 2, 12, 37],
+				"Uses": null
+			}
 		}
 	]
 }


### PR DESCRIPTION
Adds Loofah under Note-Taking, PKM Apps, and Open-Source.

I maintain Loofah. It is a local-first Mac app for notes and meeting transcription, with on-device transcription and ordinary Markdown files in a filesystem vault.

Checks:
- `npm run build`
- `git diff --check`
- site and icon URLs return HTTP 200
