### PR TITLE
Add Cozy to Apps to try

### DIFF
--- a/src/lib/data/content.json
+++ b/src/lib/data/content.json
@@ -723,6 +723,13 @@
                         "url": "https://bulkpictools.com",
                         "icon": "https://bulkpictools.com/favicon.svg",
                         "description": "Privacy-first, 100% browser-side image suite for bulk processing, powered by WebAssembly."
+                    },
+                    {
+                        "title": "Cozy",
+                        "author": "Alberto Gallego",
+                        "url": "https://cozyjournal.app",
+                        "icon": "https://cozyjournal.app/cozy.png",
+                        "description": "A journal for macOS and Windows that keeps every entry as a plain Markdown file in a folder you choose. No account, no server."
                     }
                 ]
             }


### PR DESCRIPTION
Adds [Cozy](https://cozyjournal.app) to **Join in → Apps to try**.

```json
{
    "title": "Cozy",
    "author": "Alberto Gallego",
    "url": "https://cozyjournal.app",
    "icon": "https://cozyjournal.app/cozy.png",
    "description": "A journal for macOS and Windows that keeps every entry as a plain Markdown file in a folder you choose. No account, no server."
}
```

Disclosure: I make Cozy.

**On whether it belongs here.** Cozy is local-only rather than local-first in the CRDT sense: there is no server, no account, and no built-in sync at all. Your entries are Markdown files in a folder you pick, and if you want them on a second machine you put that folder in iCloud or Dropbox yourself. That is the same shape as Obsidian, which is already on the list, so I think it fits, but it is your call and I will not argue if you would rather keep the list to apps that do the sync half too.

Appended at the end of the section, following the existing convention. Formatting and indentation are untouched, the diff is 7 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)