### PR TITLE
Add Vitra to the directory

### DIFF
--- a/src/lib/data/directory/Item.json
+++ b/src/lib/data/directory/Item.json
@@ -993,6 +993,20 @@
 				"Categories": ["L", 40, 44],
 				"Uses": null
 			}
+		},
+		{
+			"id": 85,
+			"fields": {
+				"Main_Category": 1,
+				"Title": "Vitra",
+				"slug": "vitra",
+				"author": "Pedro Thomaz",
+				"url": "https://vitrahealth.app",
+				"icon": "https://vitrahealth.app/icon.svg",
+				"description": "Local-first desktop companion for Oura Ring owners. Imports your history through the official API and keeps it synced, and every calculation runs on your own Mac or PC. No Vitra account and no vendor cloud; full JSON, CSV and PDF export.",
+				"Categories": null,
+				"Uses": null
+			}
 		}
 	]
 }


### PR DESCRIPTION
Adds one record to `src/lib/data/directory/Item.json` (id 85, Main_Category 1 / Apps). No other files touched, JSON validated.

Vitra is a desktop companion for Oura Ring owners. It pulls your history through Oura's official API and stores it on your own Mac or PC; there is no Vitra account and no server of ours in the loop, and everything exports to JSON, CSV and PDF. It is closed source and paid (one-time), so if the directory is open-source only, say the word and I will close this.

Disclosure: I built it. Two notes in case they matter to you:

- I left `Categories` as `null` because there is no health, sleep or fitness category yet. Happy to add one to `Category.json` in a follow-up if you would like the category to exist, but I did not want to invent a taxonomy entry in a drive-by PR.
- Oura's official API requires an active Oura membership, so Vitra is a companion to the subscription rather than a way around it. Mentioning it here so the listing does not imply otherwise.