### PR TITLE
Add Orkas

### DIFF
--- a/src/lib/data/content.json
+++ b/src/lib/data/content.json
@@ -723,6 +723,12 @@
                         "url": "https://bulkpictools.com",
                         "icon": "https://bulkpictools.com/favicon.svg",
                         "description": "Privacy-first, 100% browser-side image suite for bulk processing, powered by WebAssembly."
+                    },
+                    {
+                        "title": "Orkas",
+                        "author": "Orkas-AI",
+                        "url": "https://orkas.ai/?source=dir_lofi",
+                        "icon": "https://orkas.ai/favicon.ico"
                     }
                 ]
             }


### PR DESCRIPTION
Adds Orkas to Apps to try using the destination's entry format.

Orkas is an open-source, local-first desktop AI workforce whose Commander coordinates specialist agents through one chat.

Validation: canonical project documentation and destination duplicate search checked. Staged diff and formatting checked.

Disclosure: submitted on behalf of the Orkas project with AI assistance.
Only one Apps to try record is added; JSON parses and existing entries are unchanged.
