### PR TITLE
Add Daystrand to Apps directory

### DIFF
--- a/src/lib/data/directory/Item.json
+++ b/src/lib/data/directory/Item.json
@@ -993,6 +993,20 @@
 				"Categories": ["L", 40, 44],
 				"Uses": null
 			}
+		},
+		{
+			"id": 85,
+			"fields": {
+				"Main_Category": 1,
+				"Title": "Momentum",
+				"slug": "momentum",
+				"author": "Tajus Davidavicius",
+				"url": "https://tajux.gumroad.com/l/momentum",
+				"icon": "https://public-files.gumroad.com/w56okvcxq6puwxhke5qfe5p6qfu3",
+				"description": "A single HTML file habit tracker. No account, no cloud, no subscription - your data never leaves your device.",
+				"Categories": ["L", 43],
+				"Uses": null
+			}
 		}
 	]
 }


### PR DESCRIPTION
Adds Daystrand (a single HTML file habit tracker, no account/no cloud/no subscription) to the Apps directory under Task Management, alongside similar single-file local tools like TiddlyWiki and Nullboard. (Renamed from Momentum after this PR was opened; the Gumroad URL stays /l/momentum.)